### PR TITLE
Update "Generate new Token" to "Generate new ID" for writing arcs

### DIFF
--- a/lib/declarations-panel/provider/properties/ArcProps.js
+++ b/lib/declarations-panel/provider/properties/ArcProps.js
@@ -32,7 +32,7 @@ export function ArcProps(props) {
       },
     ];
 
-    // Reading arcs cannot generate new tokens. The list data class of variable arcs cannot be generated.
+    // Reading arcs cannot generate new IDs. The list data class of variable arcs cannot be generated.
     if (
       isWritingArc(element) &&
       !(element.businessObject.variableType === dataClass)
@@ -122,7 +122,7 @@ function IsGeneratedProperty(props) {
   return CheckboxEntry({
     element,
     id: dataClass.id + "isGeneratedInput",
-    label: translate("Generate new Token"),
+    label: translate("Generate new ID"),
     getValue,
     setValue,
     debounce,


### PR DESCRIPTION
As requested in the issue, the "Generate new Token" prompt in the arc properties has been changed to "Generate new ID".